### PR TITLE
fix a bug about wrong link

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,7 +27,7 @@
         {% if page.link %}
           <h1 class="entry-title" itemprop="name"><a href="{{ page.link }}">{{ page.title }}</a></h1>
         {% else %}
-          <h1 class="entry-title" itemprop="name"><a href="{{ page.url }}" rel="bookmark" title="{{ page.title }}" itemprop="url">{{ page.title }}</a></h1>
+          <h1 class="entry-title" itemprop="name"><a href="{{ site.url }}{{ page.url }}" rel="bookmark" title="{{ page.title }}" itemprop="url">{{ page.title }}</a></h1>
         {% endif %}
         <h2>{{ page.date | date: "%B %d, %Y" }}</h2>
       </div><!-- /.header-title-wrap -->


### PR DESCRIPTION
If you click the title of every post page, you will be redirected to a 404 page, because of the wrong link.
For more details, just see the _layouts/post.html.
And you can try this by click the title of such a page(http://mmistakes.github.io/hpstr-jekyll-theme/background-image/)
