### PR TITLE
Upgrade Google analytics to Google universal analytics

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -4,18 +4,14 @@
 {% if site.google_analytics %}
 <!-- Asynchronous Google Analytics snippet -->
 <script>
-  var _gaq = _gaq || [];
-  var pluginUrl = 
- '//www.google-analytics.com/plugins/ga/inpage_linkid.js';
-  _gaq.push(['_require', 'inpage_linkid', pluginUrl]);
-  _gaq.push(['_setAccount', '{{ site.google_analytics }}']);
-  _gaq.push(['_trackPageview']);
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
+  ga('create', '{{ site.google_analytics }}', 'auto');  
+  ga('require', 'linkid', 'linkid.js');
+  ga('send', 'pageview');
 </script>
 {% endif %}
 {% if page.comments %}{% include disqus_comments.html %}{% endif %}


### PR DESCRIPTION
Google [will deprecate old ga.js](https://developers.google.com/analytics/devguides/collection/upgrade/?hl=en_US). Change to new analytics.js, and also
use the new version of the enhanced link attribution module.
