### PR TITLE
change archive.html to posts.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ General notes and suggestions for customizing **HPSTR**.
 ## Setup for an Existing Jekyll site
 
 1. Clone the following folders: `_includes`, `_layouts`, `assets`, and `images`.
-2. Clone the following files and personalize content as need: `about.md`, `archive.html`, `index.html`, `tags.html`, and `feed.xml`.
+2. Clone the following files and personalize content as need: `about.md`, `posts.html`, `index.html`, `tags.html`, and `feed.xml`.
 3. Set the following variables in your `config.yml` file:
 
 ``` yaml


### PR DESCRIPTION
Just noticed a change was needed in the instructions in the README file since the archive.html files was renamed to posts.html.
