### PR TITLE
updated 'google_plus' to take an id prepended with '+'

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ owner:
   flickr:         
   tumblr:         
   # For Google Authorship https://plus.google.com/authorship
-  google_plus:    
+  # google plus id, include the '+', eg +mmistakes
+  google_plus:    +yourid
 
 # Analytics and webmaster tools stuff goes here
 google_analytics:   

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,8 @@ owner:
   flickr:         
   tumblr:         
   # For Google Authorship https://plus.google.com/authorship
-  google_plus:   
+  # google plus id, include the '+', eg +mmistakes
+  google_plus:    +yourid
 
 # Background image to be tiled on all pages
 background: 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,7 +26,7 @@
 {% capture canonical %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
 <link rel="canonical" href="{{ canonical }}">
 <link href="{{ site.url }}/feed.xml" type="application/atom+xml" rel="alternate" title="{{ site.title }} Feed">
-{% if site.owner.google_plus %}<link rel="author" href="{{ site.owner.google_plus }}?rel=author">{% endif %}
+{% if site.owner.google_plus %}<link rel="author" href="https://google.com/{{ site.owner.google_plus }}?rel=author">{% endif %}
 
 <!-- http://t.co/dKP3o1e -->
 <meta name="HandheldFriendly" content="True">

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -21,7 +21,7 @@
 					<a href="http://facebook.com/{{ site.owner.facebook }}"><i class="fa fa-facebook"></i> Facebook</a>
 				</li>{% endif %}
 				{% if site.owner.google_plus %}<li>
-					<a href="{{ site.owner.google_plus }}"><i class="fa fa-google-plus"></i> Google+</a>
+					<a href="https://google.com/{{ site.owner.google_plus }}"><i class="fa fa-google-plus"></i> Google+</a>
 				</li>{% endif %}
 				{% if site.owner.linkedin %}<li>
 					<a href="http://linkedin.com/in/{{ site.owner.linkedin }}"><i class="fa fa-linkedin"></i> LinkedIn</a>

--- a/theme-setup.md
+++ b/theme-setup.md
@@ -60,7 +60,8 @@ owner:
   flickr:         
   tumblr:         
   # For Google Authorship https://plus.google.com/authorship
-  google_plus:    
+  # google plus id, include the '+', eg +mmistakes
+  google_plus:    +yourid
 
 # Analytics and webmaster tools stuff goes here
 google_analytics:   


### PR DESCRIPTION
unlike the other accounts, google_plus required a full path. i noticed several sites 404'ing on the g+ link.

updated 'google_plus' to take an id prepended with '+' and then render links as 'https://google.com/{{ site.owner.google_plus }}'
