### PR TITLE
Fix issue:can not link to home page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,7 +1,7 @@
 <nav id="dl-menu" class="dl-menuwrapper" role="navigation">
 	<button class="dl-trigger">Open Menu</button>
 	<ul class="dl-menu">
-		<li><a href="{{ site.url }}">Home</a></li>
+		<li><a href="{{ site.url }}/">Home</a></li>
 		<li>
 			<a href="#">About</a>
 			<ul class="dl-submenu">


### PR DESCRIPTION
Hi, Michael,
First, my English is poor.
There is a problem when I deploy hpstr on github pages, if  my **_config.yml** like this:

``` raw
url: blog.zhibeiyou.net
```

Then the url on github page is like: blog.zhibeiyou.net/blog.zhibeiyou.net/my-blog/

So, my **_config.yml** is like this:

``` raw
url: 
```

Everthing is seems OK. But I can't jump to home page. 

With the modify of the patch, I can jump to home page now.
Sorry for my poor English.

Herodot
