### PR TITLE
protocol independent url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ description:      A responsive Jekyll theme with modern tendencies from designer
 disqus_shortname: hpstrtheme
 reading_time:     true
 words_per_minute: 200
-url:              http://mmistakes.github.io/hpstr-jekyll-theme
+url:              //mmistakes.github.io/hpstr-jekyll-theme
 
 # Owner/author information
 owner:


### PR DESCRIPTION
use a protocol independent url to support both `http` and `https`
