### PR TITLE
add word-wrap -> break-word

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -10,6 +10,9 @@ body {
 .entry,
 .hentry {
 	@include clearfix;
+	h1, h2, h3, h4, h5, h6, p, li {
+		word-wrap: break-word;
+	}
 }
 .entry-content {
 	@include font-size(16);


### PR DESCRIPTION
#68

add `word-wrap` to avoid breaking style in mobile if you use long word.
