### PR TITLE
Display only summaries

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ sass:
 permalink:   /:categories/:title/
 
 # Amount of post to show on home page
-paginate: 5
+paginate: 10
 
 kramdown:
   auto_ids: true

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ image:
     {% endif %}
   </header>
   <div class="entry-content">
-    {{ post.content }}
+    {{ post.summary }}
   </div><!-- /.entry-content -->
 </article><!-- /.hentry -->
 {% endfor %}


### PR DESCRIPTION
On the front page display only the summaries of articles (not the whole articles).