### PR TITLE
Introducing `include gallery` feature

### DIFF
--- a/_includes/gallery
+++ b/_includes/gallery
@@ -1,0 +1,21 @@
+{% assign images = include.images | split:" " %}
+{% assign caption = include.caption %}
+{% assign cols = include.cols %}
+
+{% case cols %}
+    {% when 1 %}
+        {% assign class = "" %}
+    {% when 2 %}
+        {% assign class = "half" %}
+    {% when 3 %}
+        {% assign class = "third" %}
+    {% else %}
+        {% assign class = "" %}
+{% endcase %}
+
+<figure {% if class != "" %}class="{{ class }}"{% endif %}>
+    {% for image in images %}
+    <a href="{{ image }}"><img src="{{ image }}" alt=""></a>
+    {% endfor %}
+    <figcaption>{{ caption }}</figcaption>
+</figure>

--- a/_posts/2013-05-22-sample-post-images.md
+++ b/_posts/2013-05-22-sample-post-images.md
@@ -62,3 +62,37 @@ And you'll get something that looks like this:
 	<a href="http://placehold.it/1200x600.jpg"><img src="http://placehold.it/600x300.jpg" alt=""></a>
 	<figcaption>Three images.</figcaption>
 </figure>
+
+### Alternative way
+
+Another way to achieve the same result is to include `gallery` Liquid template. In this case you
+don't have to write any HTML tags – just copy a small block of code, adjust the parameters (see below)
+and fill the block with any number of links to images. You can mix relative and external links.
+
+Here is the block you might want to use:
+
+{% highlight jinja %}
+{% raw %}
+{% capture images %}
+	/images/abstract-10.jpg
+	/images/abstract-11.jpg
+	http://upload.wikimedia.org/wikipedia/en/2/24/Lenna.png
+{% endcapture %}
+{% include gallery images=images caption="Test images" cols=3 %}
+{% endraw %}
+{% endhighlight %}
+
+Parameters:
+
+- `caption`: Sets the caption under the gallery (see `figcaption` HTML tag above);
+- `cols`: Sets the number of columns of the gallery.
+Available values: [1..3].
+
+It will look something like this:
+
+{% capture images %}
+	/images/abstract-10.jpg
+	/images/abstract-11.jpg
+	http://upload.wikimedia.org/wikipedia/en/2/24/Lenna.png
+{% endcapture %}
+{% include gallery images=images caption="Test images" cols=3 %}


### PR DESCRIPTION
First of all, thank you a lot for such an amazing Jekyll template! You are awesome!

I thought it might be a good idea to reduce the amount of bare HTML code in posts.

One of the great features of your blog template is an image gallery inside post. But it is a bit inconvenient to use HTML code inside the post, it ruins all the beauty of Liquid templates. Also, you have to copy the image link twice – once in the `<a>`-tag, and the second time inside the `<img>` tag.

I have created a `gallery` Liquid template, which allows to insert image galleries in the easier way. No more link copying, no more HTML tags.

There is even a better approach though – to create a separate Liquid tag. It would look something like this:
```
{% gallery cols=3 caption="Caption" %}
    (links go here)
{% endgallery %}
```
Unfortunately, GitHub pages don't allow any custom plugins (and such a custom Liquid tag is called a plugin in terms of Jekyll framework), so this solution won't work with GitHub pages. Well, `include gallery` works like a charm :-)

P.S.: this is my first pull request ever, please let me know if there is anything I'm doing wrong.