### PR TITLE
Only include read-more.html if site.related_posts.size > 0

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -50,7 +50,7 @@
       </footer>
     </div><!-- /.entry-content -->
     {% if page.comments != false %}<section id="disqus_thread"></section><!-- /#disqus_thread -->{% endif %}
-    {% if site.related_posts.size %}{% include read-more.html %}{% endif %}
+    {% if site.related_posts.size > 0 %}{% include read-more.html %}{% endif %}
   </article>
 </div><!-- /#main -->
 


### PR DESCRIPTION
When starting a fresh site based on this theme, there are no related posts. 
This fix checks that related_posts.size is > 0 before including read-more.html. 
This removes an empty related posts section at the bottom of the post page.