### PR TITLE
Don't meddle with code if it has a data-lang attribute

### DIFF
--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -98,7 +98,7 @@ tt, code, kbd, samp, pre {
 }
 p,
 li { 
-	code {
+	code:not([data-lang]) {
 		@include font-rem(12);
 		line-height: 1.5;
 		white-space: nowrap;


### PR DESCRIPTION
Those are created by redcarpet for fenced code blocks. Fixes #90.