### PR TITLE
Updated link to HPSTR theme

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,1 +1,1 @@
-<span>&copy; {{ site.time | date: '%Y' }} {{ site.owner.name }}. Powered by <a href="http://jekyllrb.com" rel="nofollow">Jekyll</a> using the <a href="http://mademistakes.com/hpstr/" rel="notfollow">HPSTR Theme</a>.</span>
+<span>&copy; {{ site.time | date: '%Y' }} {{ site.owner.name }}. Powered by <a href="http://jekyllrb.com" rel="nofollow">Jekyll</a> using the <a href="https://mademistakes.com/work/hpstr-jekyll-theme/" rel="notfollow">HPSTR Theme</a>.</span>


### PR DESCRIPTION
I noticed the old link (http://mademistakes.com/hpstr/) got redirected to https://mademistakes.com/. Information on the HPSTR theme can be found on https://mademistakes.com/work/hpstr-jekyll-theme/.