### PR TITLE
Feature/author

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,0 +1,36 @@
+# Author details.
+
+author_one:
+  name:           Author One
+  avatar:         avatar.jpg
+  bio:            "This is Author One's bio."
+  email:          author@one.com
+  # Social networking links used in footer. Update and remove as you like.
+  twitter:        
+  facebook:       
+  github:         
+  stackexchange:  
+  linkedin:       
+  instagram:      
+  flickr:         
+  tumblr:         
+  # google plus id, include the '+', eg +mmistakes
+  google_plus:    +yourid
+
+author_two:
+  name:           Author Two
+  avatar:         avatar.jpg
+  bio:            "This is Author Two's bio."
+  email:          author@two.com
+  # Social networking links used in footer. Update and remove as you like.
+  twitter:        
+  facebook:       
+  github:         
+  stackexchange:  
+  linkedin:       
+  instagram:      
+  flickr:         
+  tumblr:         
+  # google plus id, include the '+', eg +mmistakes
+  google_plus:    +yourid
+

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -48,6 +48,7 @@
 			<ul class="dl-submenu">
 				<li><a href="{{ site.url }}/posts/">All Posts</a></li>
 				<li><a href="{{ site.url }}/tags/">All Tags</a></li>
+				<li><a href="{{ site.url }}/authors/">All Authors</a></li>
 			</ul>
 		</li>
 		{% for link in site.data.navigation %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,6 +3,16 @@
 <!--[if (IE 7)&!(IEMobile)]><html class="no-js lt-ie9 lt-ie8" lang="en"><![endif]-->
 <!--[if (IE 8)&!(IEMobile)]><html class="no-js lt-ie9" lang="en"><![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"><!--<![endif]-->
+
+{% if page.author %}
+  {% assign author = site.data.authors[page.author] %}
+{% endif %}
+
+{% if author == null %}
+  {% assign author = site.owner %}
+{% endif %}
+
+
 <head>
 {% include head.html %}
 </head>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -50,11 +50,15 @@
       </div><!-- /.header-title-wrap -->
     </header>
     <div class="entry-content">
+      <header class="entry-meta">
+        Written <span class="author vcard"><span class="fn"><a href="{{ site.url }}/authors/#{{ authorID }}" title="Posts by {{ author.name }}">{{ author.name }}</a></span></span>
+        {% if page.modified %}
+          <span>(last updated on <span class="entry-date date updated"><time datetime="{{ page.modified }}">{{ page.modified | date: "%B %d, %Y" }}</time></span>)</span>
+        {% endif %}
+      </header>
       {{ content }}
       <footer class="entry-meta">
         <span class="entry-tags">{% for tag in page.tags %}<a href="{{ site.url }}/tags/#{{ tag }}" title="Pages tagged {{ tag }}" class="tag"><span class="term">{{ tag }}</span></a>{% unless forloop.last %}{% endunless %}{% endfor %}</span>
-        {% if page.modified %}<span>Updated on <span class="entry-date date updated"><time datetime="{{ page.modified }}">{{ page.modified | date: "%B %d, %Y" }}</time></span></span>
-        <span class="author vcard"><span class="fn">{{ site.owner.name }}</span></span>{% endif %}
         {% if page.share != false %}{% include social-share.html %}{% endif %}
       </footer>
     </div><!-- /.entry-content -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,12 +6,11 @@
 
 {% if page.author %}
   {% assign author = site.data.authors[page.author] %}
-{% endif %}
-
-{% if author == null %}
+  {% capture authorID %}{{ page.author }}{% endcapture %}
+{% else %}
   {% assign author = site.owner %}
+  {% capture authorID %}owner{% endcapture %}
 {% endif %}
-
 
 <head>
 {% include head.html %}

--- a/_templates/page
+++ b/_templates/page
@@ -1,6 +1,7 @@
 ---
 layout: {{ layout }}
 title: {{ title }}
+author:
 date: {{ date }}
 modified:
 description:

--- a/_templates/post
+++ b/_templates/post
@@ -1,6 +1,7 @@
 ---
 layout: {{ layout }}
 title: {{ title }}
+author:
 modified:
 categories: {{ dir }}
 description:

--- a/authors/index.html
+++ b/authors/index.html
@@ -8,13 +8,26 @@ comments: false
 {% capture site_authors %}{% for author in site.data.authors %}{{ author | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
 {% assign authors_list = site_authors | split:',' | sort %}
 
-<!-- TODO Count number of posts by each author -->
+<!-- Count number of posts by owner -->
+{% assign nb_posts = 0 %}
+{% for post in site.posts %}
+  {% if post.author == null %}
+    {% assign nb_posts = nb_posts | plus: 1 %}
+  {% endif %}
+{% endfor %}
 
 <ul class="entry-meta inline-list">
-  	<li><a href="#owner" class="tag"><span class="term">{{ site.owner.name }}</span></a></li>
+  	<li><a href="#owner" class="tag"><span class="term">{{ site.owner.name }}</span> <span class="count">{{ nb_posts }}</span></a></li>
   {% for item in (0..site.data.authors.size) %}{% unless forloop.last %}
     {% capture this_word %}{{ authors_list[item] | strip_newlines }}{% endcapture %}
-  	<li><a href="#{{ this_word }}" class="tag"><span class="term">{{ site.data.authors[this_word].name }}</span></a></li>
+    <!-- Count number of posts by this author -->
+    {% assign nb_posts = 0 %}
+    {% for post in site.posts %}
+    {% if post.author == authors_list[item] %}
+        {% assign nb_posts = nb_posts | plus: 1 %}
+      {% endif %}
+    {% endfor %}
+  	<li><a href="#{{ this_word }}" class="tag"><span class="term">{{ site.data.authors[this_word].name }}</span> <span class="count">{{ nb_posts }}</span></a></li>
   {% endunless %}{% endfor %}
 </ul>
 

--- a/authors/index.html
+++ b/authors/index.html
@@ -1,0 +1,43 @@
+---
+layout: post-index
+title: Author Archive
+description: "An archive of posts sorted by author."
+comments: false
+---
+
+{% capture site_authors %}{% for author in site.data.authors %}{{ author | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
+{% assign authors_list = site_authors | split:',' | sort %}
+
+<!-- TODO Count number of posts by each author -->
+
+<ul class="entry-meta inline-list">
+  	<li><a href="#owner" class="tag"><span class="term">{{ site.owner.name }}</span></a></li>
+  {% for item in (0..site.data.authors.size) %}{% unless forloop.last %}
+    {% capture this_word %}{{ authors_list[item] | strip_newlines }}{% endcapture %}
+  	<li><a href="#{{ this_word }}" class="tag"><span class="term">{{ site.data.authors[this_word].name }}</span></a></li>
+  {% endunless %}{% endfor %}
+</ul>
+
+<article>
+  <h2 id="owner" class="author-heading">{{ site.owner.name }}</h2>
+  <ul>
+    {% for post in site.posts %}
+      {% if post.author == null %}
+        <li class="entry-title"><a href="{{ site.url }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+</article><!-- /.hentry -->
+{% for item in (0..site.data.authors.size) %}{% unless forloop.last %}
+  {% capture this_word %}{{ authors_list[item] | strip_newlines }}{% endcapture %}
+	<article>
+	<h2 id="{{ this_word }}" class="author-heading">{{ site.data.authors[this_word].name }}</h2>
+		<ul>
+    {% for post in site.posts %}
+      {% if post.author == this_word %}
+        <li class="entry-title"><a href="{{ site.url }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
+      {% endif %}
+    {% endfor %}
+		</ul>
+	</article><!-- /.hentry -->
+{% endunless %}{% endfor %}

--- a/index.html
+++ b/index.html
@@ -11,6 +11,15 @@ image:
 ---
 
 {% for post in paginator.posts %}
+
+{% if post.author %}
+  {% assign author = site.data.authors[post.author] %}
+  {% capture authorID %}{{ post.author }}{% endcapture %}
+{% else %}
+  {% assign author = site.owner %}
+  {% capture authorID %}owner{% endcapture %}
+{% endif %}
+
 <article class="hentry">
   <header>
     {% if post.image.feature %}
@@ -19,7 +28,7 @@ image:
       </div><!-- /.entry-image -->
     {% endif %}
     <div class="entry-meta">
-      <span class="entry-date date published updated"><time datetime="{{ post.date | date_to_xmlschema }}"><a href="{{ site.url }}{{ post.url }}">{{ post.date | date: "%B %d, %Y" }}</a></time></span><span class="author vcard"><span class="fn"><a href="{{ site.url }}/about/" title="About {{ page.author.name }}">{{ page.author.name }}</a></span></span>
+      <span class="entry-date date published updated"><time datetime="{{ post.date | date_to_xmlschema }}"><a href="{{ site.url }}{{ post.url }}">{{ post.date | date: "%B %d, %Y" }}</a></time></span><span class="author vcard"><span class="fn"><a href="{{ site.url }}/authors/#{{ authorID }}" title="Posts by {{ author.name }}">{{ author.name }}</a></span></span>
       {% if site.reading_time %}
       <span class="entry-reading-time">
         <i class="fa fa-clock-o"></i>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ image:
       </div><!-- /.entry-image -->
     {% endif %}
     <div class="entry-meta">
-      <span class="entry-date date published updated"><time datetime="{{ post.date | date_to_xmlschema }}"><a href="{{ site.url }}{{ post.url }}">{{ post.date | date: "%B %d, %Y" }}</a></time></span><span class="author vcard"><span class="fn"><a href="{{ site.url }}/about/" title="About {{ site.owner.name }}">{{ site.owner.name }}</a></span></span>
+      <span class="entry-date date published updated"><time datetime="{{ post.date | date_to_xmlschema }}"><a href="{{ site.url }}{{ post.url }}">{{ post.date | date: "%B %d, %Y" }}</a></time></span><span class="author vcard"><span class="fn"><a href="{{ site.url }}/about/" title="About {{ page.author.name }}">{{ page.author.name }}</a></span></span>
       {% if site.reading_time %}
       <span class="entry-reading-time">
         <i class="fa fa-clock-o"></i>

--- a/theme-setup/index.md
+++ b/theme-setup/index.md
@@ -97,6 +97,9 @@ bundle exec jekyll serve
 
 {% highlight bash %}
 hpstr-jekyll-theme/
+├── _data
+|    ├── authors.yml                # post authors
+|    └── navigation.yml             # menu navigation links
 ├── _includes
 |    ├── browser-upgrade.html       # prompt to upgrade browser on < IE8
 |    ├── footer.html                # site footer

--- a/theme-setup/index.md
+++ b/theme-setup/index.md
@@ -30,7 +30,7 @@ General notes and suggestions for customizing **HPSTR**.
 ## Setup for an Existing Jekyll site
 
 1. Clone the following folders: `_includes`, `_layouts`, '_sass', `assets`, and `images`.
-2. Clone the following folders/files and personalize content as need: `about/`, `posts/`, `tags/`, `feed.xml`. and 'index.html'.
+2. Clone the following folders/files and personalize content as need: `about/`, `posts/`, `authors/`, `tags/`, `feed.xml`. and 'index.html'.
 3. Set the following variables in your `config.yml` file:
 
 {% highlight yaml %}
@@ -123,6 +123,7 @@ hpstr-jekyll-theme/
 ├── _config.yml                     # Jekyll options
 ├── about/                          # about page
 ├── posts/                          # all posts
+├── authors/                        # all posts grouped by author
 ├── tags/                           # all posts grouped by tag
 └── index.html                      # home page with pagination
 {% endhighlight %}


### PR DESCRIPTION
This branch adds the ability to define multiple authors for a site. 
Each post can be attributed to an author. 
Posts can be listed by author.
The post layout has been modified to feature the author more prominently (top of the page instead of bottom).
The author name now consistently links to that author's list of posts. Previously, the owner name in a post index would link to the owner's about page and in a post it would not link to anything.

This is still a little rough around the edges:
- I added some references in the theme-setup page. But maybe there should be more text explaining how to use the feature or how to disable it for those not interested.
- Maybe each author should have an about page that the author name would link to.
- Maybe the author in a post should show the avatar and links to twitter and such.
- Should the sidebar change based on the current page? It could show information about the current page's author.
- The way the number of posts for each author is counted is not the most efficient. This is the best I could come up with given that liquid seems to be limited in its support for arrays. Maybe sites with hundreds of authors and thousands of posts would take a few more seconds to generate...

One thing I did not add to this pull request: I modified a few posts from the template to attribute them to the 2 demo authors. This may help users understand how to use the feature. Let me know if you want me to add this to the pull request.

Please share your thoughts here so we can refine this functionality together.