### PR TITLE
Removing HTML before checking the word count

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -34,7 +34,7 @@
         {% if site.reading_time %}
         <p class="entry-reading-time">
           <i class="fa fa-clock-o"></i>
-          {% assign readtime = content | number_of_words | divided_by:site.words_per_minute %}
+          {% assign readtime = content | strip_html | number_of_words | divided_by:site.words_per_minute %}
           Reading time ~{% if readtime <= 1 %}1 minute{% else %}{{ readtime }} minutes{% endif %}
         </p><!-- /.entry-reading-time -->
         {% endif %}

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ image:
       {% if site.reading_time %}
       <span class="entry-reading-time">
         <i class="fa fa-clock-o"></i>
-        {% assign readtime = post.content | number_of_words | divided_by:site.words_per_minute %}
+        {% assign readtime = post.content | strip_html | number_of_words | divided_by:site.words_per_minute %}
         Reading time ~{% if readtime <= 1 %}1 minute{% else %}{{ readtime }} minutes{% endif %}
       </span><!-- /.entry-reading-time -->
       {% endif %}


### PR DESCRIPTION
I think HTML should be stripped from the content prior to checking the number of words. Otherwise your total word count/reading time is inflated.

For a really simple post I made my word code went from 409 to 306. I double checked the output of the stripped content and is much cleaner since it is missing all markup.

Enjoy.