### PR TITLE
Improve page load by moving hidden navigation div the bottom of the page.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -10,7 +10,6 @@
 <body id="page" {% if page.image.feature %}class="feature"{% endif %}>
 
 {% include browser-upgrade.html %}
-{% include navigation.html %}
 
 {% if page.image.feature %}
 <div class="entry-header">
@@ -53,6 +52,7 @@
   </footer>
 </div><!-- /.footer-wrapper -->
 
+{% include navigation.html %}
 {% include scripts.html %}          
 
 </body>

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -10,7 +10,6 @@
 <body id="post-index" {% if page.image.feature %}class="feature"{% endif %}>
 
 {% include browser-upgrade.html %}
-{% include navigation.html %}
 
 <div class="entry-header">
   {% if page.image.credit %}<div class="image-credit">Image source: <a href="{{ page.image.creditlink }}">{{ page.image.credit }}</a></div><!-- /.image-credit -->{% endif %}
@@ -37,6 +36,7 @@
   </footer>
 </div><!-- /.footer-wrapper -->
 
+{% include navigation.html %}
 {% include scripts.html %}          
 
 </body>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,7 +10,6 @@
 <body id="post" {% if page.image.feature %}class="feature"{% endif %}>
 
 {% include browser-upgrade.html %}
-{% include navigation.html %}
 
 {% if page.image.feature %}
 <div class="entry-header">
@@ -60,6 +59,7 @@
   </footer>
 </div><!-- /.footer-wrapper -->
 
+{% include navigation.html %}
 {% include scripts.html %}	        
 
 </body>


### PR DESCRIPTION
The Navigation <div> was one of the first things to load in browser, yet it's
hidden on page load. This means a larger "avatar" image would be one of the
first elements that the browser spends times loading, even though it may never
be viewed.

After making this change, the browser renders the page just the same, but I
saw total load times on my own blog drop from about 3 seconds to 2.5 seconds--
A notable improvement.