### PR TITLE
Globally disable disqus comments

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -42,7 +42,7 @@
         {% if page.share != false %}{% include social-share.html %}{% endif %}
       </footer>
     </div><!-- /.entry-content -->
-    {% if page.comments != false %}<section id="disqus_thread"></section><!-- /#disqus_thread -->{% endif %}
+    {% if page.comments != false and site.disqus_shortname %}<section id="disqus_thread"></section><!-- /#disqus_thread -->{% endif %}
   </article>
 </div><!-- /#main -->
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -48,7 +48,7 @@
         {% if page.share != false %}{% include social-share.html %}{% endif %}
       </footer>
     </div><!-- /.entry-content -->
-    {% if page.comments != false %}<section id="disqus_thread"></section><!-- /#disqus_thread -->{% endif %}
+    {% if page.comments != false and site.disqus_shortname %}<section id="disqus_thread"></section><!-- /#disqus_thread -->{% endif %}
     {% if site.related_posts.size > 0 %}{% include read-more.html %}{% endif %}
   </article>
 </div><!-- /#main -->


### PR DESCRIPTION
Now, leaving out a disqus name in _config.yml will have the same effect
as turning comments off on each individual page.

Previously, the `section#disqus_thread` element was still getting placed on the page even if there was no Disqus shortname.