### PR TITLE
Adds `og:image` tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,9 @@ owner:
 # Background image to be tiled on all pages
 background: 
 
+# Open Graph image to be used as a fallback when there are no images specified for a page/post
+open_graph_image: avatar.jpg
+
 # Analytics and webmaster tools stuff goes here
 google_analytics:   
 google_verify:      

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,6 +19,9 @@
 <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 <meta property="og:url" content="{{ site.url }}{{ page.url }}">
 <meta property="og:site_name" content="{{ site.title }}">
+{% if page.image.facebook %}<meta property="og:image" content="{{ site.url }}/images/{{ page.image.facebook }}">{% endif %}
+{% if page.image.feature %}<meta property="og:image" content="{{ site.url }}/images/{{ page.image.feature }}">{% endif %}
+{% if page.image.feature == null and page.feature.facebook == null and site.open_graph_image != null %}<meta property="og:image" content="{{ site.url }}/images/{{ site.open_graph_image }}">{% endif %}
 
 {% if site.google_verify %}<meta name="google-site-verification" content="{{ site.google_verify }}">{% endif %}
 {% if site.bing_verify %}<meta name="msvalidate.01" content="{{ site.bing_verify }}">{% endif %}


### PR DESCRIPTION
`page.image.facebook` and `page.image.feature` will add `og:image` meta
tags to the page. Since the protocol allows multiple images, both will
be used if they are both available. If neither are present and the
`_config.yml` specifies an `open_graph_image`, then that will be used.