### PR TITLE
Image path pseudo function

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,9 +5,9 @@
 
 {% if site.owner.twitter %}<!-- Twitter Cards -->
 {% if page.image.feature %}<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="{{ site.url }}/images/{{ page.image.feature }}">
+<meta name="twitter:image" content="{% include image_path image=page.image.feature %}">
 {% else %}<meta name="twitter:card" content="summary">
-<meta name="twitter:image" content="{% if page.image.thumb %}{{ site.url }}/images/{{ page.image.thumb }}{% else %}{{ site.url }}/images/{{ site.logo }}{% endif %}">{% endif %}
+<meta name="twitter:image" content="{% if page.image.thumb %}{% include image_path image=page.image.thumb }}{% else %}{% include image_path image=site.logo %}{% endif %}">{% endif %}
 <meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
 <meta name="twitter:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 <meta name="twitter:creator" content="@{{ site.owner.twitter }}">{% endif %}
@@ -58,6 +58,5 @@
 
 {% if page.image.background or site.background %}
 {% capture background %}{% if page.image.background %}{{ page.image.background }}{% else %}{{ site.background }}{% endif %}{% endcapture %}
-{% unless background contains 'http://' or background contains 'https://' %}{% capture background %}{{ site.url }}/images/{{ background }}{% endcapture %}{% endunless %}
-<style type="text/css">body {background-image:url({{ background }});}</style>
+<style type="text/css">body {background-image:url({% include image_path image=background %});}</style>
 {% endif %}

--- a/_includes/image_path
+++ b/_includes/image_path
@@ -1,0 +1,11 @@
+{% comment %}
+This file will prepend the image path `{{site.url}}/images/` to any image
+that does not have two slashes `//` in the path. That way, an image url that
+points to another website won't automatically have this website mistakenly
+added to the front of the url.
+
+A string beginning with a single slash will be prepended with {{ site.url }}
+
+This file must NOT have an extra carriage return at the end.
+
+{% endcomment %}{% capture first %}{{ include.image | truncate: 1, '' }}{% endcapture %}{% if include.image contains '//' %}{{ include.image }}{% elsif first == '/' %}{{ site.url }}{{ include.image }}{% else %}{{ site.url }}/images/{{ include.image }}{% endif %}

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,7 +6,7 @@
 			<a href="#">About</a>
 			<ul class="dl-submenu">
 				<li>
-					<img src="{{ site.url }}/images/{{ site.owner.avatar }}" alt="{{ site.owner.name }} photo" class="author-photo">
+					<img src="{% include image_path image=site.owner.avatar }}" alt="{{ site.owner.name %} photo" class="author-photo">
 					<h4>{{ site.owner.name }}</h4>
 					<p>{{ site.owner.bio }}</p>
 				</li>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -16,7 +16,7 @@
 <div class="entry-header">
   {% if page.image.credit %}<div class="image-credit">Image source: <a href="{{ page.image.creditlink }}">{{ page.image.credit }}</a></div><!-- /.image-credit -->{% endif %}
   <div class="entry-image">
-    <img src="{{ site.url }}/images/{{ page.image.feature }}" alt="{{ page.title }}">
+    <img src="{% include image_path image=page.image.feature }}" alt="{{ page.title %}">
   </div><!-- /.entry-image -->
 </div><!-- /.entry-header -->
 {% endif %}

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -16,7 +16,7 @@
   {% if page.image.credit %}<div class="image-credit">Image source: <a href="{{ page.image.creditlink }}">{{ page.image.credit }}</a></div><!-- /.image-credit -->{% endif %}
   {% if page.image.feature %}
     <div class="entry-image">
-      <img src="{{ site.url }}/images/{{ page.image.feature }}" alt="{{ page.title }}">
+      <img src="{% include image_path image=page.image.feature }}" alt="{{ page.title %}">
     </div><!-- /.entry-image -->
   {% endif %}
   <div class="header-title">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,7 +16,7 @@
 <div class="entry-header">
   {% if page.image.credit %}<div class="image-credit">Image source: {% if page.image.creditlink %}<a href="{{ page.image.creditlink }}">{% endif %}{{ page.image.credit }}{% if page.image.creditlink %}</a>{% endif %}</div><!-- /.image-credit -->{% endif %}
   <div class="entry-image">
-    <img src="{{ site.url }}/images/{{ page.image.feature }}" alt="{{ page.title }}">
+    <img src="{% include image_path image=page.image.feature }}" alt="{{ page.title %}">
   </div><!-- /.entry-image -->
 </div><!-- /.entry-header -->
 {% endif %}

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ image:
   <header>
     {% if post.image.feature %}
       <div class="entry-image-index">
-        <a href="{{ site.url }}{{ post.url }}" title="{{ post.title }}"><img src="{{ site.url }}/images/{{ post.image.feature }}" alt="{{ post.title }}"></a>
+        <a href="{{ site.url }}{{ post.url }}" title="{{ post.title }}"><img src="{% include image_path image=post.image.feature }}" alt="{{ post.title %}"></a>
       </div><!-- /.entry-image -->
     {% endif %}
     <div class="entry-meta">


### PR DESCRIPTION
Same idea as `gallery` in the `_includes` folder. This one handles image urls and will prepend the `{{site.url}}` or `{{site.url}}/images/` intelligently… or will prepend nothing at all in the case where the string contains `//` anywhere.

This is a way to make the functionality for background image apply universally to all image paths.

(As such, I replaced the logic that created the background image path with this new technique as well.)