### PR TITLE
Improve Twitter cards & Open Graph tags.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,10 @@ owner:
   # google plus id, include the '+', eg +mmistakes
   google_plus:
 
+# Twitter account associated with the site if different from owner/author twitter account.
+# Used in Twitter cards.
+twitter: 
+
 # Background image to be tiled on all pages
 background: 
 
@@ -36,6 +40,7 @@ bing_verify:
 
 # http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 timezone:    America/New_York
+locale:      en_US
 future:      true
 highlighter: rouge
 markdown:    kramdown

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,22 +3,21 @@
 <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 {% if page.tags %}<meta name="keywords" content="{{ page.tags | join: ', ' }}">{% endif %}
 
-{% if site.owner.twitter %}<!-- Twitter Cards -->
+{% if site.owner.twitter or site.twitter %}<!-- Twitter Cards -->
 {% if page.image.feature %}<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="{{ site.url }}/images/{{ page.image.feature }}">
-{% else %}<meta name="twitter:card" content="summary">
-<meta name="twitter:image" content="{% if page.image.thumb %}{{ site.url }}/images/{{ page.image.thumb }}{% else %}{{ site.url }}/images/{{ site.logo }}{% endif %}">{% endif %}
-<meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
-<meta name="twitter:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
-<meta name="twitter:creator" content="@{{ site.owner.twitter }}">{% endif %}
+{% else %}<meta name="twitter:card" content="summary">{% endif %}
+<meta name="twitter:site" content="@{% if site.twitter %}{{ site.twitter }}{% else %}{{ site.owner.twitter }}{% endif %}">
+<meta name="twitter:creator" content="@{% if site.owner.twitter %}{{ site.owner.twitter }}{% else %}{{ site.twitter }}{% endif %}">{% endif %}
 
 <!-- Open Graph -->
-<meta property="og:locale" content="en_US">
+<meta property="og:locale" content="{{ site.locale }}">
 <meta property="og:type" content="article">
 <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
 <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 <meta property="og:url" content="{{ site.url }}{{ page.url }}">
 <meta property="og:site_name" content="{{ site.title }}">
+{% if page.image.feature %}<meta property="og:image" content="{{ site.url }}/images/{{ page.image.feature }}">
+{% else %}<meta property="og:image" content="{% if page.image.thumb %}{{ site.url }}/images/{{ page.image.thumb }}{% else %}{{ site.url }}/images/{{ site.logo }}{% endif %}">{% endif %}
 
 {% if site.google_verify %}<meta name="google-site-verification" content="{{ site.google_verify }}">{% endif %}
 {% if site.bing_verify %}<meta name="msvalidate.01" content="{{ site.bing_verify }}">{% endif %}


### PR DESCRIPTION
Fixes the following issues:

__*Issue 1:*__
Twitter cards require the ':site' tag.

> twitter:site
> @username of website. Either twitter:site or twitter:site:id is required.

Ref: https://dev.twitter.com/cards/markup

The `site` tag is supposed to be used for the site specific twitter account, the `creator` tag for the twitter account of the author or the article.

Adding a config variable for the site twitter account to account for this.

Twitter tags will be shown if either (`site.twitter` or `site.owner.twitter`) is available.
Both tags will fall back to each other.

__*Issue 2:*__
Twitter cards will automatically fall back to Open graph tags if available, so we can remove the Twitter specific title and description tags as those are duplicated in the open graph tags.

Also, the OG tags did not have the image tag while twitter did, so moving those from twitter to OG, to make them available to both.

Ref: https://dev.twitter.com/cards/getting-started#opengraph

__*Issue 3:*__
Not all sites are written in US english.

Adding a config variable to set the locale of a site.