### PR TITLE
Image feature can be on another site

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -16,7 +16,11 @@
 <div class="entry-header">
   {% if page.image.credit %}<div class="image-credit">Image source: <a href="{{ page.image.creditlink }}">{{ page.image.credit }}</a></div><!-- /.image-credit -->{% endif %}
   <div class="entry-image">
-    <img src="{{ site.url }}/images/{{ page.image.feature }}" alt="{{ page.title }}">
+      {% if page.image.feature contains 'http://' or page.image.feature contains 'https://' %}
+        <img src="{{ page.image.feature }}" alt="{{ page.title }}">
+      {% else %}
+        <img src="{{ site.url }}/images/{{ page.image.feature }}" alt="{{ page.title }}">
+      {% endif %} 
   </div><!-- /.entry-image -->
 </div><!-- /.entry-header -->
 {% endif %}

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -16,7 +16,11 @@
   {% if page.image.credit %}<div class="image-credit">Image source: <a href="{{ page.image.creditlink }}">{{ page.image.credit }}</a></div><!-- /.image-credit -->{% endif %}
   {% if page.image.feature %}
     <div class="entry-image">
-      <img src="{{ site.url }}/images/{{ page.image.feature }}" alt="{{ page.title }}">
+      {% if page.image.feature contains 'http://' or page.image.feature contains 'https://' %}
+        <img src="{{ page.image.feature }}" alt="{{ page.title }}">
+      {% else %}
+        <img src="{{ site.url }}/images/{{ page.image.feature }}" alt="{{ page.title }}">
+      {% endif %} 
     </div><!-- /.entry-image -->
   {% endif %}
   <div class="header-title">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,7 +16,11 @@
 <div class="entry-header">
   {% if page.image.credit %}<div class="image-credit">Image source: {% if page.image.creditlink %}<a href="{{ page.image.creditlink }}">{% endif %}{{ page.image.credit }}{% if page.image.creditlink %}</a>{% endif %}</div><!-- /.image-credit -->{% endif %}
   <div class="entry-image">
-    <img src="{{ site.url }}/images/{{ page.image.feature }}" alt="{{ page.title }}">
+      {% if page.image.feature contains 'http://' or page.image.feature contains 'https://' %}
+        <img src="{{ page.image.feature }}" alt="{{ page.title }}">
+      {% else %}
+        <img src="{{ site.url }}/images/{{ page.image.feature }}" alt="{{ page.title }}">
+      {% endif %} 
   </div><!-- /.entry-image -->
 </div><!-- /.entry-header -->
 {% endif %}


### PR DESCRIPTION
If the image feature is on another space in the internet, it can be displayed as a feature image.

For example if a site is on `sitea.com`, and the image is on `siteb.com`, `sitea.com` can link to that image. Without this, an outside image will look like this: `http://sitea.com/images/http://siteb.com/image.jpg`