### PR TITLE
Fix missing `json` dependency in `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "json"
 gem "jekyll", "~> 3.0"
 gem "jekyll-sitemap"
 gem "octopress"


### PR DESCRIPTION
The `bundle exec jekyll build` didn't work on my Fedora 23 x86_64 until I added this to `Gemfile`.

I couldn't find answers on stackoverflow and ended up with [my own explanation][1].

[1]: http://stackoverflow.com/a/36819950/441652