### PR TITLE
show dotted line underlines for more links

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -17,8 +17,7 @@ body {
 .entry-content {
 	@include font-size(16);
 	// Dotted line underlines for links
-	p > a,
-	li > a {
+	a {
 		border-bottom: 1px dotted lighten($link-color, 50);
 		&:hover {
 			border-bottom-style: solid;
@@ -316,8 +315,7 @@ header .entry-meta {
 .read-more-content {
 	@include font-size(16);
 	// Dotted line underlines for links
-	p > a,
-	li > a {
+	a {
 		border-bottom: 1px dotted lighten($link-color, 50);
 		&:hover {
 			border-bottom-style: solid;


### PR DESCRIPTION
previously anchor tags in italicized or bolded text would not display any differently and were difficult to notice.