### PR TITLE
Add option to disable social share links site-wide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ description:      Describe your website here.
 disqus_shortname: 
 reading_time:     true
 words_per_minute: 200
+share: true # turn social share links on/off site-wide
 # Your site's domain goes here (eg: https://mmistakes.github.io, http://yourdomain.com, etc)
 # When testing locally leave blank or use http://localhost:4000
 url:

--- a/_config.yml
+++ b/_config.yml
@@ -62,6 +62,14 @@ kramdown:
   toc_levels: 1..6
   enable_coderay: false
 
+defaults:
+  -
+    scope:
+      path: ""
+      type: "posts"
+    values:
+      share: true # turn on social links by default
+
 include: 
   - .htaccess
 exclude: 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -39,7 +39,7 @@
       <footer class="entry-meta">
         {% if page.modified %}<span>Updated on <span class="entry-date date published updated"><time datetime="{{ page.modified }}">{{ page.modified | date: "%B %d, %Y" }}</time></span></span>
         <span class="author vcard"><span class="fn">{{ site.owner.name }}</span></span>{% endif %}
-        {% if page.share %}{% include social-share.html %}{% endif %}
+        {% if site.share and page.share %}{% include social-share.html %}{% endif %}
       </footer>
     </div><!-- /.entry-content -->
     {% if page.comments != false and site.disqus_shortname %}<section id="disqus_thread"></section><!-- /#disqus_thread -->{% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -39,7 +39,7 @@
       <footer class="entry-meta">
         {% if page.modified %}<span>Updated on <span class="entry-date date published updated"><time datetime="{{ page.modified }}">{{ page.modified | date: "%B %d, %Y" }}</time></span></span>
         <span class="author vcard"><span class="fn">{{ site.owner.name }}</span></span>{% endif %}
-        {% if page.share != false %}{% include social-share.html %}{% endif %}
+        {% if page.share %}{% include social-share.html %}{% endif %}
       </footer>
     </div><!-- /.entry-content -->
     {% if page.comments != false and site.disqus_shortname %}<section id="disqus_thread"></section><!-- /#disqus_thread -->{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -45,7 +45,7 @@
         <span class="entry-tags">{% for tag in page.tags %}<a href="{{ site.url }}/tags/#{{ tag }}" title="Pages tagged {{ tag }}" class="tag"><span class="term">{{ tag }}</span></a>{% unless forloop.last %}{% endunless %}{% endfor %}</span>
         {% if page.modified %}<span>Updated on <span class="entry-date date updated"><time datetime="{{ page.modified }}">{{ page.modified | date: "%B %d, %Y" }}</time></span></span>
         <span class="author vcard"><span class="fn">{{ site.owner.name }}</span></span>{% endif %}
-        {% if page.share != false %}{% include social-share.html %}{% endif %}
+        {% if page.share %}{% include social-share.html %}{% endif %}
       </footer>
     </div><!-- /.entry-content -->
     {% if page.comments != false and site.disqus_shortname %}<section id="disqus_thread"></section><!-- /#disqus_thread -->{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -45,7 +45,7 @@
         <span class="entry-tags">{% for tag in page.tags %}<a href="{{ site.url }}/tags/#{{ tag }}" title="Pages tagged {{ tag }}" class="tag"><span class="term">{{ tag }}</span></a>{% unless forloop.last %}{% endunless %}{% endfor %}</span>
         {% if page.modified %}<span>Updated on <span class="entry-date date updated"><time datetime="{{ page.modified }}">{{ page.modified | date: "%B %d, %Y" }}</time></span></span>
         <span class="author vcard"><span class="fn">{{ site.owner.name }}</span></span>{% endif %}
-        {% if page.share %}{% include social-share.html %}{% endif %}
+        {% if site.share and page.share %}{% include social-share.html %}{% endif %}
       </footer>
     </div><!-- /.entry-content -->
     {% if page.comments != false and site.disqus_shortname %}<section id="disqus_thread"></section><!-- /#disqus_thread -->{% endif %}


### PR DESCRIPTION
I personally don't care about social sharing links on my site. I think others might also like the ability to turn this off for the whole site from the config.

I also was able to remove the check for 'if not equal false', which is not considered best coding practices. This changes make the logic in the layouts a little more readable, and gives the extra 'site-wide' disable option.