### PR TITLE
Fixes json compilation error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     jekyll-sitemap (0.10.0)
     jekyll-watch (1.4.0)
       listen (~> 3.0, < 3.1)
-    json (1.8.3)
+    json (1.8.5)
     kramdown (1.11.1)
     liquid (3.0.6)
     listen (3.0.8)


### PR DESCRIPTION
After running "gem install json -v '1.8.3'" i get the following error:
"generator.c:861:25: error: ‘rb_cFixnum’ undeclared (first use in this function)"
This seems to fix it